### PR TITLE
Add boolean flag to enable all resources for SES IAM user

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "ses_user_policy" {
 
   statement {
     actions   = var.iam_permissions
-    resources = [join("", aws_ses_domain_identity.ses_domain.*.arn)]
+    resources = var.enable_all_iam_resources ? ["*"] : [join("", aws_ses_domain_identity.ses_domain.*.arn)]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,9 @@ variable "iam_permissions" {
   description = "Specifies permissions for the IAM user."
   default     = ["ses:SendRawEmail"]
 }
+
+variable "enable_all_iam_resources" {
+  type = bool
+  description = "Specifies either all resources for the IAM user or just the aws_ses_domain_identity ARNs."
+  default = true
+}


### PR DESCRIPTION
This flag is especially useful when dealing with wildcards and needing to have open permissions from other senders that aren't ARNs
